### PR TITLE
Add Everything (EV) token — Arbitrum One

### DIFF
--- a/src/tokens/arbitrum-one.json
+++ b/src/tokens/arbitrum-one.json
@@ -2789,5 +2789,14 @@
     "logoURI": "BASE_URL/assets/cyWBTC.png",
     "decimals": 8,
     "quote": "other"
+  },
+  {
+    "chainId": 42161,
+    "symbol": "EV",
+    "name": "Everything",
+    "address": "0xE7E7E741C23a4767831A56A8C99F522c5aC1E7E7",
+    "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/39394.png",
+    "decimals": 18,
+    "quote": "other"
   }
 ]


### PR DESCRIPTION
## Token Information

| Field | Value |
|---|---|
| **Name** | Everything |
| **Symbol** | EV |
| **Address** | `0xE7E7E741C23a4767831A56A8C99F522c5aC1E7E7` |
| **Decimals** | 18 |
| **Chain** | Arbitrum One (chainId: 42161) |

## Links

- **Website:** https://everything.inc/
- **CoinMarketCap:** https://coinmarketcap.com/currencies/everything/ (#308, ~$62M market cap)
- **Arbiscan:** https://arbiscan.io/token/0xE7E7E741C23a4767831A56A8C99F522c5aC1E7E7

## Why add this token?

Everything (EV) is an ERC-20 token ranked #308 on CoinMarketCap with ~2.16K holders on Arbitrum and active trading volume. The contract is verified on Arbiscan.